### PR TITLE
Cell 클릭 시 FormVC로 이동 구현

### DIFF
--- a/Todolist/Todolist/Presentation/Form/FormViewController.swift
+++ b/Todolist/Todolist/Presentation/Form/FormViewController.swift
@@ -37,6 +37,13 @@ final class FormViewController: UIViewController {
     }()
     private lazy var stackView = FormStackView()
 
+    convenience init(task: Task) {
+        self.init(nibName: nil, bundle: nil)
+
+        stackView.textFieldRx.text.onNext(task.context)
+        stackView.switchRx.isOn.onNext(task.isDaily)
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
         configure()

--- a/Todolist/Todolist/Presentation/Tasks/TasksViewController.swift
+++ b/Todolist/Todolist/Presentation/Tasks/TasksViewController.swift
@@ -104,9 +104,11 @@ private extension TasksViewController {
             .map { [weak self] indexPath in
                 return self?.viewModel.allTasks.value[indexPath.row]
             }
-            .subscribe(onNext: { task in
+            .subscribe(onNext: { [weak self] task in
                 if let task = task {
-                    print(task.context)
+                    let controller = FormViewController(task: task)
+
+                    self?.navigationController?.pushViewController(controller, animated: true)
                 }
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
close #27 

- [x] Cell 클릭 시 Form VC로 이동
- [x] 넘어온 Task를 바탕으로 TextField, Switch 초기화

데이터 가져오는 기능까지만 구현돼있어서,
그대로 addButton을 클릭하면 같은 내용이 추가됨.
(이 부분은 곧바로 cell update, delete 작업 시 구현할 예정)