### PR TITLE
navigation backbutton title 제거

### DIFF
--- a/Todolist/Todolist/Presentation/Tasks/TasksViewController.swift
+++ b/Todolist/Todolist/Presentation/Tasks/TasksViewController.swift
@@ -74,6 +74,7 @@ private extension TasksViewController {
 
         navigationItem.rightBarButtonItems = [formBarButton, settingsBarButton]
         navigationItem.title = Date.today
+        navigationItem.backButtonTitle = Const.navigationBackButtonTitle
 
         view.addSubview(tableView)
     }

--- a/Todolist/Todolist/Resources/Const.swift
+++ b/Todolist/Todolist/Resources/Const.swift
@@ -13,6 +13,7 @@ enum Const {
     static let settingsButtonImage = "gearshape.fill"
     static let checkButtonNormalImage = "circle"
     static let checkButtonSelectedImage = "checkmark.circle.fill"
+    static let navigationBackButtonTitle = ""
 
     // Form
     static let tempIDForNewTask = -1


### PR DESCRIPTION
SettingsVC 진입시 back button에 표시되던 TasksVC의 Title(날짜)을 제거하였습니다.

결과
<img width="423" alt="image" src="https://user-images.githubusercontent.com/48671169/183839141-2cd51ec8-31ff-4008-b725-1df37ab870b9.png">
