### PR TITLE
Realm 0.0.2 마이그레이션 구현

### DIFF
--- a/Todolist/Todolist/Application/AppDelegate.swift
+++ b/Todolist/Todolist/Application/AppDelegate.swift
@@ -13,6 +13,8 @@ final class AppDelegate: UIResponder, UIApplicationDelegate {
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
     ) -> Bool {
+        RealmStorage.migration()
+
         return true
     }
 

--- a/Todolist/Todolist/Data/Storages/RealmStorage.swift
+++ b/Todolist/Todolist/Data/Storages/RealmStorage.swift
@@ -10,6 +10,26 @@ import Foundation
 import RealmSwift
 
 enum RealmStorage {
+    static func migration() {
+        let configuration = Realm.Configuration(
+            schemaVersion: 2,
+            migrationBlock: { migration, oldSchemaVersion in
+                if oldSchemaVersion < 2 {
+                    migration.enumerateObjects(ofType: Task.className()) { oldObject, newObject in
+                        guard let oldObject = oldObject,
+                              let newObject = newObject else { return }
+
+                        newObject["title"] = oldObject["context"]
+                        newObject["isDone"] = oldObject["isChecked"]
+                        newObject["createdDate"] = Date()
+                    }
+                }
+            }
+        )
+
+        Realm.Configuration.defaultConfiguration = configuration
+    }
+
     static func taskResults() -> Results<Task>? {
         guard let realm = try? Realm() else { return nil }
 


### PR DESCRIPTION
close #91 

버전 업그레이드시 Realm 모델의 스키마가 달라질 때를 대비한 마이그레이션 코드입니다.
schemaVersion이 UInt64 타입이여서 0.0.0 -> 0, 0.0.2 -> 2로 작성했습니다. (추후 1.0.1 일경우 101)